### PR TITLE
Shuffle candidate order once per day

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "babel-core": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "express": "^4.16.2",
+    "moment": "^2.19.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "serve-static": "^1.13.1",
+    "seedrandom": "^2.4.3",
+    "shuffle-array": "^1.0.1",
     "webpack": "^3.7.1"
   },
   "babel": {

--- a/src/components/CandidateProfiles.js
+++ b/src/components/CandidateProfiles.js
@@ -1,11 +1,23 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router'
 
+var moment = require('moment');
+var seedrandom = require('seedrandom');
+var shuffle = require('shuffle-array');
+
 class CandidateProfiles extends Component {
     render() {
+        var today = moment().format('YYYY-MM-DD');
+        var shuffleOptions = {
+            'copy': true,
+            'rng': seedrandom(today)
+        };
+        var shuffledCandidates = shuffle(
+            this.props.candidates,
+            shuffleOptions);
         return (
           <div className="row">
-            {this.props.candidates.map(c =>
+            {shuffledCandidates.map(c =>
               <div key={c.id} className="col-md-6 col-lg-4 col-xl-3">
                 <div className="candidate" onClick={() =>
                   this.props.history.push(`/candidate/${c.id}`)


### PR DESCRIPTION
Displaying candidates in alphabetical order can cause bias towards the ones at the beginning.

This introduces a shuffle based on an RNG whose seed value changes once per day.